### PR TITLE
add visible support and creator links

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,22 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [ComfyUI](https://github.com/comfyanonymous/ComfyUI) for the amazing framework
 - [BiRefNet](https://github.com/ZhengPeng7/BiRefNet) for the matting models
 - [RMBG](https://github.com/briaai/RMBG-2.0) for the background removal model
+
+---
+
+## ❤️ 支持与关注 / Support & Follow
+
+> 开源代码可以免费，但显卡、电费、服务器和咖啡豆暂时还没学会开源。
+
+你好，我是**赛博迪克朗**。我平时给 AI 喂提示词、给 ComfyUI 接管线，也负责修复那些“昨天明明还能跑”的神秘问题。教程里看起来三分钟解决的事，背后往往是三十次失败和一句又一句“这不应该啊”。
+
+如果这个项目帮你少踩了一个坑、少重装了一次环境，那些和报错窗口深情对视的夜晚就算没有白熬。欢迎通过下面的方式支持和关注：
+
+- [💙 支付宝 / Alipay](https://github.com/whmc76/.github/blob/main/SUPPORT.md#alipay)
+- [🌍 PayPal](https://paypal.me/CyberDickLang)
+- [📺 哔哩哔哩 / Bilibili](https://space.bilibili.com/339984)
+- [▶️ YouTube](https://www.youtube.com/@CyberDickLang)
+
+抖音、小红书、快手、今日头条、微信视频号、X：搜索全网统一名称 **“赛博迪克朗”**。
+
+**不赞助也完全没关系。** 使用、Star、反馈、分享，甚至一句“这东西真能用”，都是继续更新的动力。谢谢你让这个项目不只是躺在我的硬盘里感动自己。


### PR DESCRIPTION
## What changed

- add a visible support and creator section to the project README
- link PayPal, Alipay, Bilibili, and YouTube
- list the unified creator name `赛博迪克朗` for other social platforms
- keep sponsorship explicitly optional while thanking users for stars, feedback, and sharing

## Why

Default community files provide shared funding data, but GitHub does not inject their prose into each repository homepage. This README section makes the support and community information visible without requiring visitors to discover a separate file first.

## Validation

- `git diff --check`
- only README files were changed
- confirmed channel and funding URLs are shared consistently
